### PR TITLE
Adding SendDiagnosticInterrupt to MFA requirement

### DIFF
--- a/security_controls_scp/modules/ec2/main.tf
+++ b/security_controls_scp/modules/ec2/main.tf
@@ -6,6 +6,7 @@ data "aws_iam_policy_document" "require_mfa_ec2_actions" {
     actions = [
       "ec2:StopInstances",
       "ec2:TerminateInstances",
+      "ec2:SendDiagnosticInterrupt",
     ]
 
     resources = [


### PR DESCRIPTION
Adding `ec2:SendDiagnosticInterrupt` to the list of high risk ec2 calls by requiring MFA to utilize. 

This is in reference to #16 