### PR TITLE
S3 updates

### DIFF
--- a/security_controls_scp/README.md
+++ b/security_controls_scp/README.md
@@ -53,6 +53,7 @@ The following SCPs should only be applied after the account has been configured 
     - Denies non-TLS S3 Requests
 - Requires MFA When Deleting Objects
 - Denies the creation of publicly facing [Access Points](https://aws.amazon.com/s3/features/access-points/).
+- Restricts the region(s) where S3 buckets can be created. Update the variables file [here](https://github.com/ScaleSec/terraform_aws_scp/blob/master/security_controls_scp/variables.tf).
 
 ### AWS Shield
 

--- a/security_controls_scp/main.tf
+++ b/security_controls_scp/main.tf
@@ -54,7 +54,8 @@ module "organizations" {
 module "s3" {
   source = "./modules/s3"
 
-  target_id = var.target_id
+  target_id       = var.target_id
+  region_lockdown = var.region_lockdown
 }
 
 ## Deploy Shield AWS Org SCPs

--- a/security_controls_scp/modules/s3/main.tf
+++ b/security_controls_scp/modules/s3/main.tf
@@ -148,3 +148,47 @@ resource "aws_organizations_policy_attachment" "deny_public_access_points_attach
   policy_id = aws_organizations_policy.deny_public_access_points_policy.id
   target_id = var.target_id
 }
+
+
+data "aws_iam_policy_document" "s3_region_lockdown_document" {
+  statement {
+    sid = "S3RegionLockdown"
+
+    actions = [
+      "s3:CreateBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+    
+      test     = "StringNotLike"
+      variable = "s3locationconstraint"
+      values = var.region_lockdown
+    }
+    condition {
+
+      test    = "Null"
+      variable = "s3locationconstraint"
+      values = [
+        "false",
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "s3_region_lockdown_policy" {
+  name        = "Restrict S3 Regions"
+  description = "Restricts the region(s) where S3 buckets can be created."
+
+  content = data.aws_iam_policy_document.s3_region_lockdown_document.json
+}
+
+resource "aws_organizations_policy_attachment" "s3_region_lockdown_attachment" {
+  policy_id = aws_organizations_policy.s3_region_lockdown_policy.id
+  target_id = var.target_id
+}

--- a/security_controls_scp/modules/s3/variables.tf
+++ b/security_controls_scp/modules/s3/variables.tf
@@ -3,3 +3,8 @@ variable "target_id" {
   description = "The Root ID, Organizational Unit ID, or AWS Account ID to apply SCPs."
   type        = string
 }
+
+variable "region_lockdown" {
+  description = "The AWS region(s) you want to restrict resources to."
+  type        = list(string)
+}

--- a/security_controls_scp/variables.tf
+++ b/security_controls_scp/variables.tf
@@ -4,3 +4,12 @@ variable "target_id" {
   type        = string
 }
 
+variable "region_lockdown" {
+  description = "The AWS region(s) you want to restrict resources to."
+  type        = list(string)
+  default = [
+    "us-east-1",
+    "us-east-2",
+    "us-west-1"
+  ]
+}


### PR DESCRIPTION
New SCP which blocks S3 bucket creation unless it is in approved regions. This PR adds a new variable `region_lockdown` which allows the user to select multiple regions to allow bucket creation in.

Keep in mind this SCP does not assign permissions or allow users to create a bucket and that must be added through IAM. 

This resolves #28 