### PR TITLE
EC2 ami lockdown

### DIFF
--- a/security_controls_scp/README.md
+++ b/security_controls_scp/README.md
@@ -30,6 +30,11 @@ The following SCPs should only be applied after the account has been configured 
 
 - Requires MFA when deleting or stopping EC2 instances.
   - A best practice is to protect your resources from accidental deletions and requiring MFA is one step in that direction. 
+- Locks down the AMIs that can be launched to only the AMI creation account.
+  - A common practice is to configure an AWS account for centralized AMI creations that you then share to the receiving accounts. Similiar to a hub-and-spoke model.
+- Requires a resource tag key/value pair to launch EC2s.
+  - Requiring a specific resource tag key/value pair on an AMI in order to launch an EC2 instande is a form of ABAC (Attribute-Based Access Control). ABAC is a powerful access control configuration that AWS is supporting more and more with updates. For an in-depth breakdown of ABAC, visit this [tutorial](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html). Combining ABAC in the form of a resource tag and locking down AMIs to only specific owners/account IDs allows you to put different security checks in place for a layered approach.
+
 
 ### GuardDuty
 

--- a/security_controls_scp/main.tf
+++ b/security_controls_scp/main.tf
@@ -27,7 +27,7 @@ module "ec2" {
   source = "./modules/ec2"
 
   target_id         = var.target_id
-  AmiCreatorAccount = var.AmiCreatorAccount
+  ami_creator_account = var.ami_creator_account
   ami_tag_key       = var.ami_tag_key
   ami_tag_value     = var.ami_tag_value
 }

--- a/security_controls_scp/main.tf
+++ b/security_controls_scp/main.tf
@@ -28,6 +28,8 @@ module "ec2" {
 
   target_id         = var.target_id
   AmiCreatorAccount = var.AmiCreatorAccount
+  ami_tag_key       = var.ami_tag_key
+  ami_tag_value     = var.ami_tag_value
 }
 
 ## Deploy GuardDuty AWS Org SCPs

--- a/security_controls_scp/main.tf
+++ b/security_controls_scp/main.tf
@@ -26,7 +26,8 @@ module "cloudtrail" {
 module "ec2" {
   source = "./modules/ec2"
 
-  target_id = var.target_id
+  target_id         = var.target_id
+  AmiCreatorAccount = var.AmiCreatorAccount
 }
 
 ## Deploy GuardDuty AWS Org SCPs

--- a/security_controls_scp/modules/ec2/main.tf
+++ b/security_controls_scp/modules/ec2/main.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "restrict_ec2_ami_document" {
       variable = "ec2:Owner"
 
       values = [
-        var.AmiCreatorAccount
+        var.ami_creator_account
       ]
     }
 
@@ -106,7 +106,6 @@ data "aws_iam_policy_document" "require_ami_tag_document" {
         var.ami_tag_value
       ]
     }
-
   }
 }
 

--- a/security_controls_scp/modules/ec2/main.tf
+++ b/security_controls_scp/modules/ec2/main.tf
@@ -1,4 +1,7 @@
 #-----security_controls_scp/modules/ec2/main.tf----#
+
+## Requires a MFA'd account to perform certain EC2 Actions
+
 data "aws_iam_policy_document" "require_mfa_ec2_actions" {
   statement {
     sid = "RequireMFAEC2"
@@ -35,5 +38,45 @@ resource "aws_organizations_policy" "require_mfa_ec2_actions" {
 
 resource "aws_organizations_policy_attachment" "require_mfa_ec2_actions_attachment" {
   policy_id = aws_organizations_policy.require_mfa_ec2_actions.id
+  target_id = var.target_id
+}
+
+## Locks down which AMIs can be launched
+
+data "aws_iam_policy_document" "restrict_ec2_ami_document" {
+  statement {
+    sid = "RestrictEc2Ami"
+
+    actions = [
+      "ec2:RunInstances"
+    ]
+
+    resources = [
+      "arn:aws:ec2:*::image/ami-*"
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "ec2:Owner"
+
+      values = [
+        var.AmiCreatorAccount
+      ]
+    }
+
+  }
+}
+
+resource "aws_organizations_policy" "restrict_ec2_ami_policy" {
+  name        = "Retrict EC2 AMIs"
+  description = "Restricts the AMIs that can be launched to the AMI creator account."
+
+  content = data.aws_iam_policy_document.restrict_ec2_ami_document.json
+}
+
+resource "aws_organizations_policy_attachment" "restrict_ec2_ami_attachment" {
+  policy_id = aws_organizations_policy.restrict_ec2_ami_policy.id
   target_id = var.target_id
 }

--- a/security_controls_scp/modules/ec2/main.tf
+++ b/security_controls_scp/modules/ec2/main.tf
@@ -45,7 +45,7 @@ resource "aws_organizations_policy_attachment" "require_mfa_ec2_actions_attachme
 
 data "aws_iam_policy_document" "restrict_ec2_ami_document" {
   statement {
-    sid = "RestrictEc2Ami"
+    sid = "RestrictEC2AMI"
 
     actions = [
       "ec2:RunInstances"

--- a/security_controls_scp/modules/ec2/main.tf
+++ b/security_controls_scp/modules/ec2/main.tf
@@ -80,3 +80,44 @@ resource "aws_organizations_policy_attachment" "restrict_ec2_ami_attachment" {
   policy_id = aws_organizations_policy.restrict_ec2_ami_policy.id
   target_id = var.target_id
 }
+
+
+## Requires a resource tag on an AMI to launch an EC2 (ABAC)
+
+data "aws_iam_policy_document" "require_ami_tag_document" {
+  statement {
+    sid = "RequireAMIResourceTag"
+
+    actions = [
+      "ec2:RunInstances"
+    ]
+
+    resources = [
+      "arn:aws:ec2:*::image/ami-*"
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "StringNotEqualsIgnoreCase"
+      variable = "ec2:ResourceTag/${var.ami_tag_key}"
+
+      values = [
+        var.ami_tag_value
+      ]
+    }
+
+  }
+}
+
+resource "aws_organizations_policy" "require_ami_tag_policy" {
+  name        = "Require AMI Tags for EC2."
+  description = "Requires a specific Resource Tag Key/Value pair in order to deploy EC2 instances."
+
+  content = data.aws_iam_policy_document.require_ami_tag_document.json
+}
+
+resource "aws_organizations_policy_attachment" "require_ami_tag_attachment" {
+  policy_id = aws_organizations_policy.require_ami_tag_policy.id
+  target_id = var.target_id
+}

--- a/security_controls_scp/modules/ec2/variables.tf
+++ b/security_controls_scp/modules/ec2/variables.tf
@@ -4,7 +4,7 @@ variable "target_id" {
   type        = string
 }
 
-variable "AmiCreatorAccount" {
+variable "ami_creator_account" {
   description = "The AWS account ID that is responsible for creating and sharing EC2 AMIs."
   type        = string
 }

--- a/security_controls_scp/modules/ec2/variables.tf
+++ b/security_controls_scp/modules/ec2/variables.tf
@@ -8,3 +8,13 @@ variable "AmiCreatorAccount" {
   description = "The AWS account ID that is responsible for creating and sharing EC2 AMIs."
   type        = string
 }
+
+variable "ami_tag_key" {
+  description = "The Resource Tag Key to lockdown AMIs for ABAC."
+  type        = string
+}
+
+variable "ami_tag_value" {
+  description = "The Resource Tag Value to lockdown AMIs for ABAC."
+  type        = string
+}

--- a/security_controls_scp/modules/ec2/variables.tf
+++ b/security_controls_scp/modules/ec2/variables.tf
@@ -3,3 +3,8 @@ variable "target_id" {
   description = "The Root ID, Organizational Unit ID, or AWS Account ID to apply SCPs."
   type        = string
 }
+
+variable "AmiCreatorAccount" {
+  description = "The AWS account ID that is responsible for creating and sharing EC2 AMIs."
+  type        = string
+}

--- a/security_controls_scp/variables.tf
+++ b/security_controls_scp/variables.tf
@@ -14,7 +14,7 @@ variable "region_lockdown" {
   ]
 }
 
-variable "AmiCreatorAccount" {
+variable "ami_creator_account" {
   description = "The AWS account ID that is responsible for creating and sharing EC2 AMIs."
   type        = string
 }

--- a/security_controls_scp/variables.tf
+++ b/security_controls_scp/variables.tf
@@ -18,3 +18,13 @@ variable "AmiCreatorAccount" {
   description = "The AWS account ID that is responsible for creating and sharing EC2 AMIs."
   type        = string
 }
+
+variable "ami_tag_key" {
+  description = "The Resource Tag Key to lockdown AMIs for ABAC."
+  type        = string
+}
+
+variable "ami_tag_value" {
+  description = "The Resource Tag Value to lockdown AMIs for ABAC."
+  type        = string
+}

--- a/security_controls_scp/variables.tf
+++ b/security_controls_scp/variables.tf
@@ -13,3 +13,8 @@ variable "region_lockdown" {
     "us-west-1"
   ]
 }
+
+variable "AmiCreatorAccount" {
+  description = "The AWS account ID that is responsible for creating and sharing EC2 AMIs."
+  type        = string
+}


### PR DESCRIPTION
This PR adds two new SCPs for EC2s around AMI lockdowns. 

- First SCP requires the AMI be owned by specific account you set.
- Second SCP requires the AMI to have a specific Resource tag key / value pair (not case sensitive) in order to launch an EC2.

Both of these SCPs can be combined together or used in addition to other controls for a safe guardrail to launching only approved AMIs.