### PR TITLE
rds_unencrypted updates

### DIFF
--- a/security_controls_scp/modules/rds/main.tf
+++ b/security_controls_scp/modules/rds/main.tf
@@ -1,0 +1,43 @@
+#-----security_controls_scp/modules/rds/main.tf----#
+
+data "aws_iam_policy_document" "deny_unencrypted_rds_actions" {
+  statement {
+    sid = "DenyUnencryptedRds"
+
+    actions = [
+      "rds:CreateDBCluster",
+      "rds:CreateDBInstance",
+      "rds:RestoreDBClusterFromS3",
+      "rds:RestoreDBInstanceFromS3",
+      "rds:RestoreDBClusterFromDBSnapshot",
+      "rds:RestoreDBClusterToPointInTime",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "Bool"
+      variable = "rds:StorageEncrypted"
+
+      values = [
+        "false",
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "deny_unencrypted_rds_actions" {
+  name        = "Deny Unencrypted RDS Actions"
+  description = "Deny any unencrypted RDS action that supports an encryption parameter."
+
+  content = data.aws_iam_policy_document.deny_unencrypted_rds_actions.json
+}
+
+resource "aws_organizations_policy_attachment" "deny_unencrypted_rds_actions_attachment" {
+  policy_id = aws_organizations_policy.deny_unencrypted_rds_actions.id
+  target_id = var.target_id
+}

--- a/security_controls_scp/modules/rds/variables.tf
+++ b/security_controls_scp/modules/rds/variables.tf
@@ -1,0 +1,5 @@
+#-----security_controls_scp/modules/rds/variables.tf----#
+variable "target_id" {
+  description = "The Root ID, Organizational Unit ID, or AWS Account ID to apply SCPs."
+  type        = string
+}


### PR DESCRIPTION
Expanding our SCP coverage to include RDS encryption. With AWS-managed keys available theres no reason anyone wouldn't use encryption for their databases.