### PR TITLE
ec2 public ami deny

### DIFF
--- a/security_controls_scp/modules/ec2/main.tf
+++ b/security_controls_scp/modules/ec2/main.tf
@@ -120,3 +120,43 @@ resource "aws_organizations_policy_attachment" "require_ami_tag_attachment" {
   policy_id = aws_organizations_policy.require_ami_tag_policy.id
   target_id = var.target_id
 }
+
+
+## Denies Users from launching EC2s from Public AMIs
+
+data "aws_iam_policy_document" "deny_ec2_public_ami" {
+  statement {
+    sid = "DenyEc2PublicAMI"
+
+    actions = [
+      "ec2:RunInstances",
+    ]
+
+    resources = [
+      "arn:aws:ec2:*::image/*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "Bool"
+      variable = "ec2:Public"
+
+      values = [
+        "true",
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "deny_ec2_public_ami" {
+  name        = "Deny EC2 Public AMI"
+  description = "Denies users the ability to launch EC2 instances with public AMIs."
+
+  content = data.aws_iam_policy_document.deny_ec2_public_ami.json
+}
+
+resource "aws_organizations_policy_attachment" "deny_ec2_public_ami_attachment" {
+  policy_id = aws_organizations_policy.deny_ec2_public_ami.id
+  target_id = var.target_id
+}


### PR DESCRIPTION
A lot of organizations have their own internal AMIs with pre-baked security agents and other applications. If users have the ability to launch EC2s with public AMIs, they can circumvent the security tools. The SCP in this PR requires users to use _private_ AMIs. Organizations can take this one step further if they'd like and add the SCP [Require AMI Tags for EC2](https://github.com/ScaleSec/terraform_aws_scp/blob/330e4bb1753a094f869f270d8f9578025164b25c/security_controls_scp/modules/ec2/main.tf#L87) to further lockdown which AMIs can be launched via ABAC.

Closes #30 