### PR TITLE
Lambda VPC SCP

### DIFF
--- a/security_controls_scp/main.tf
+++ b/security_controls_scp/main.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  region  = "us-east-1"
 }
 
 ## Deploy Account AWS Org SCPs

--- a/security_controls_scp/modules/lambda/main.tf
+++ b/security_controls_scp/modules/lambda/main.tf
@@ -1,0 +1,45 @@
+#-----security_controls_scp/modules/lambda/main.tf----#
+
+##############################################################################
+## Requires lambda functions to be deployed in a customer owned VPC.        ##
+## By default, lambda functions are deployed in a VPC owned by AWS / Lambda ##
+##############################################################################
+
+
+data "aws_iam_policy_document" "require_vpc_lambda" {
+  statement {
+    sid = "RequireLambdaInVpc"
+
+    actions = [
+      "lambda:CreateFunction",
+      "lambda:UpdateFunctionConfiguration"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+
+      test    = "Null"
+      variable = "lambda:VpcIds"
+      values = [
+        "true",
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "require_vpc_lambda" {
+  name        = "Lambda in Customer VPC"
+  description = "Requires lambdas to be deployed in a customer owned VPC."
+
+  content = data.aws_iam_policy_document.require_vpc_lambda.json
+}
+
+resource "aws_organizations_policy_attachment" "require_vpc_lambda_attachment" {
+  policy_id = aws_organizations_policy.require_vpc_lambda.id
+  target_id = var.target_id
+}

--- a/security_controls_scp/modules/lambda/variables.tf
+++ b/security_controls_scp/modules/lambda/variables.tf
@@ -1,0 +1,5 @@
+#-----security_controls_scp/modules/lambda/variables.tf----#
+variable "target_id" {
+  description = "The Root ID, Organizational Unit ID, or AWS Account ID to apply SCPs."
+  type        = string
+}


### PR DESCRIPTION
Hot off the press! AWS released new condition keys for lambda functions. This PR contains a SCP to require lambdas be deployed in a customer-owned VPC. 

I also hardcoded the provider region to `us-east-1` 

Closes #48 