### PR TITLE
EC2 Public IP Deny SCP

### DIFF
--- a/security_controls_scp/modules/ec2/deny_public_ec2_ip.tf
+++ b/security_controls_scp/modules/ec2/deny_public_ec2_ip.tf
@@ -1,0 +1,40 @@
+#-----security_controls_scp/modules/ec2/deny_public_ec2_ip.tf----#
+
+## Denies Users from launching EC2s with public IPs
+
+data "aws_iam_policy_document" "deny_ec2_public_ip_document" {
+  statement {
+    sid = "DenyEc2PublicIp"
+
+    actions = [
+      "ec2:RunInstances",
+    ]
+
+    resources = [
+      "arn:aws:ec2:*:*:network-interface/*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "Bool"
+      variable = "ec2:AssociatePublicIpAddress"
+
+      values = [
+        "true",
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "deny_ec2_public_ip" {
+  name        = "Deny EC2s with Public IPs"
+  description = "Denies users the ability to launch an EC2 with a public IP"
+
+  content = data.aws_iam_policy_document.deny_ec2_public_ip_document.json
+}
+
+resource "aws_organizations_policy_attachment" "deny_ec2_public_ip_attachment" {
+  policy_id = aws_organizations_policy.deny_ec2_public_ip.id
+  target_id = var.target_id
+}


### PR DESCRIPTION
As mentioned in #56 there are a couple of ways to make an EC2 public. We are a little limited with options as far as SCPs go but are able to deny the ability for an end user to specifically configure a public IP when launching an EC2. We cannot block the user from selecting a subnet that auto-assigns public IPs without having knowledge of what those subnet IDs are. We could make a SCP to deny launching an EC2 into specific subnet IDs using the `ec2:Subnet` condition if people think thats something they'd use. 



Fixes #56 