### PR TITLE
region restriction scp for non-global services and APIs

### DIFF
--- a/security_controls_scp/README.md
+++ b/security_controls_scp/README.md
@@ -94,3 +94,6 @@ The following SCPs should only be applied after the account has been configured 
   - VPC Flow Logs are your network monitoring logs and provide visibility into anomalous traffic during a security event. 
 
 
+### Region
+
+- [region_restriction.tf](./modules/region/region_restriction.tf) - Restricts the region(s) where AWS non-global services APIs can be invoked. Update the variables file [here](https://github.com/ScaleSec/terraform_aws_scp/blob/master/security_controls_scp/variables.tf)

--- a/security_controls_scp/README.md
+++ b/security_controls_scp/README.md
@@ -96,4 +96,4 @@ The following SCPs should only be applied after the account has been configured 
 
 ### Region
 
-- [region_restriction.tf](./modules/region/region_restriction.tf) - Restricts the region(s) where AWS non-global services APIs can be invoked. Update the variables file [here](https://github.com/ScaleSec/terraform_aws_scp/blob/master/security_controls_scp/variables.tf)
+- [region_restriction.tf](./modules/region/region_restriction.tf) - Restricts the region(s) where AWS non-global services APIs can be invoked. Update the variables file [here](https://github.com/ScaleSec/terraform_aws_scp/blob/master/security_controls_scp/variables.tf). More information on this SCP can be found [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_deny-requested-region.html).

--- a/security_controls_scp/main.tf
+++ b/security_controls_scp/main.tf
@@ -97,3 +97,11 @@ module "vpc" {
 
   target_id = var.target_id
 }
+
+## Deploy Region Restriction AWS Org SCPs
+module "region" {
+  source = "./modules/region"
+
+  target_id       = var.target_id
+  region_lockdown = var.region_lockdown
+}

--- a/security_controls_scp/modules/region/region_restriction.tf
+++ b/security_controls_scp/modules/region/region_restriction.tf
@@ -1,0 +1,45 @@
+#-----security_controls_scp/modules/account/deny_region_usage.tf----#
+
+data "aws_iam_policy_document" "region_restriction" {
+  statement {
+    sid = "DenyRegionUsage"
+
+    not_actions = [
+      "cloudfront:*",
+      "iam:*",
+      "route53:*",
+      "support:*",
+      "organizations:*",
+      "waf:*",
+      "budgets:*",
+      "globalaccelerator:*",
+      "cur:*",
+      "ce:*",
+      "directconnect:*"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "StringNotEqualsIgnoreCase"
+      variable = "aws:RequestedRegion"
+      values = var.region_lockdown
+    }
+  }
+}
+
+resource "aws_organizations_policy" "region_restriction" {
+  name        = "Deny Region Interaction"
+  description = "Deny the ability to invoke APIs in regions outside the above"
+
+  content = data.aws_iam_policy_document.region_restriction.json
+}
+
+resource "aws_organizations_policy_attachment" "region_restriction_attachment" {
+  policy_id = aws_organizations_policy.region_restriction.id
+  target_id = var.target_id
+}

--- a/security_controls_scp/modules/region/variables.tf
+++ b/security_controls_scp/modules/region/variables.tf
@@ -1,0 +1,10 @@
+#-----security_controls_scp/modules/s3/variables.tf----#
+variable "target_id" {
+  description = "The Root ID, Organizational Unit ID, or AWS Account ID to apply SCPs."
+  type        = string
+}
+
+variable "region_lockdown" {
+  description = "The AWS region(s) you want to restrict resources to."
+  type        = list(string)
+}


### PR DESCRIPTION
This SCP will prevent usage of AWS Services (non-global) APIs from being invoked in non-authorized regions.