### PR TITLE
Extend IMDS control

### DIFF
--- a/security_controls_scp/modules/ec2/require_imdsv2.tf
+++ b/security_controls_scp/modules/ec2/require_imdsv2.tf
@@ -4,7 +4,7 @@
 
 data "aws_iam_policy_document" "require_imdsv2" {
   statement {
-    sid = "RequireIMDSv2"
+    sid = "RequireEc2InstancesToUseImdsV2"
 
     actions = [
       "ec2:RunInstances"
@@ -25,11 +25,71 @@ data "aws_iam_policy_document" "require_imdsv2" {
       ]
     }
   }
+  
+  statement {
+    sid = "RequireEc2RolesToUseImdsV2"
+
+    actions = [
+      "*"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "ec2:RoleDelivery"
+
+      values = [
+        "2.0",
+      ]
+    }
+  }
+
+  statement {
+    sid = "DenyDisableImdsV2"
+
+    actions = [
+      "ec2:ModifyInstanceMetadataOptions"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Deny"
+  }
+
+  statement {
+    sid = "MaxImdsHopLimit"
+
+    actions = [
+      "ec2:RunInstances"
+    ]
+
+    resources = [
+      "arn:aws:ec2:*:*:instance/*",
+    ]
+
+    effect = "Deny"
+
+    condition {
+      test     = "NumericLessThan"
+      variable = "ec2:MetadataHttpPutResponseHopLimit"
+
+      values = [
+        "1",
+      ]
+    }
+  }
 }
 
 resource "aws_organizations_policy" "require_imdsv2_org_policy" {
   name        = "Require IMDSv2 For EC2"
-  description = "Requires the use of IMDSv2 for newly launched EC2s"
+  description = "Requires IMDSv2 for EC2 instances and roles"
 
   content = data.aws_iam_policy_document.require_imdsv2.json
 }


### PR DESCRIPTION
Improves IMDSv2 enforcement by not just requiring new instances to use it, but also: require all instance roles to use it, deny disabling it, and set a max hop limit so it can't be abused.