### PR TITLE
Add SCP to deny KMS custom key store

### DIFF
--- a/security_controls_scp/modules/kms/deny_kms_custom_key_store.tf
+++ b/security_controls_scp/modules/kms/deny_kms_custom_key_store.tf
@@ -1,0 +1,33 @@
+#-----security_controls_scp/modules/kms/deny_kms_custom_key_store.tf----#
+
+data "aws_iam_policy_document" "deny_kms_custom_key_store" {
+  statement {
+    sid = "DenyKmsCustomKeyStore"
+
+    actions = [
+      "kms:CreateCustomKeyStore",
+      "kms:UpdateCustomKeyStore",
+      "kms:ConnectCustomKeyStore",
+      "kms:DisconnectCustomKeyStore",
+      "kms:DeleteCustomKeyStore",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    effect = "Deny"
+  }
+}
+
+resource "aws_organizations_policy" "deny_kms_custom_key_store" {
+  name        = "Deny KMS custom key store"
+  description = "Deny the ability to use KMS custom key store
+
+  content = data.aws_iam_policy_document.deny_kms_custom_key_store.json
+}
+
+resource "aws_organizations_policy_attachment" "deny_kms_custom_key_store_attachment" {
+  policy_id = aws_organizations_policy.deny_kms_custom_key_store.id
+  target_id = var.target_id
+}

--- a/security_controls_scp/modules/kms/variables.tf
+++ b/security_controls_scp/modules/kms/variables.tf
@@ -1,0 +1,5 @@
+#-----security_controls_scp/modules/kms/variables.tf----#
+variable "target_id" {
+  description = "The Root ID, Organizational Unit ID, or AWS Account ID to apply SCPs."
+  type        = string
+}


### PR DESCRIPTION
KMS custom key store is uncommon and provides a risky mechanism for ransomware, most orgs should deny usage unless they have a particular use case.

See https://medium.com/@harsh8v/redefining-ransomware-attacks-on-aws-using-aws-kms-xks-dea668633802