### PR TITLE
fix: align with AWS documentation

### DIFF
--- a/security_controls_scp/modules/ai/ai_services_opt_out.tf
+++ b/security_controls_scp/modules/ai/ai_services_opt_out.tf
@@ -7,6 +7,7 @@ resource "aws_organizations_policy" "ai_services_opt_out" {
   content     = <<CONTENT
   {
     "services": {
+        "@@operators_allowed_for_child_policies": ["@@none"],
         "default": {
             "@@operators_allowed_for_child_policies": ["@@none"],
             "opt_out_policy": {


### PR DESCRIPTION
Aligns with AWS documentation on opt out examples. See example 1:
https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out_syntax.html#ai-opt-out-policy-examples